### PR TITLE
Travis ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - 'iojs'
+  - '0.12'
+  - '0.10'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-jasmine-terminal-reporter
+jasmine-terminal-reporter [![Build Status](https://travis-ci.org/jbblanchet/jasmine-terminal-reporter.svg?branch=master)](https://travis-ci.org/jbblanchet/jasmine-terminal-reporter)
 =========================
 
 A simple terminal reporter for Jasmine, inspired by [juliemr/minijasminenode](https://github.com/juliemr/minijasminenode).


### PR DESCRIPTION
Setup travis-ci to test the project.

I added a .travis.yaml file that will run the tests agains node 0.10, 0.12 and io.js. These are the same versions that sindresorhus/gulp-jasmine tests against.

Added the nifty travis build status badge in the readme. Note that the badge is hardcoded for the master branch of the jbblanchet/jasmine-terminal-reporter repo. It appears to be impossible to have an image that works for any fork / branch. See https://github.com/travis-ci/travis-ci/issues/779

TODO for jbblanchet: 
1. Login to https://travis-ci.org/ with your github account
2. Go to https://travis-ci.org/profile
3. Check the jbblanchet/jasmine-terminal-reporter checkbox
4. Push something on master
5. ???
6. Profit!