### PR TITLE
handle disabled status correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ module.exports = function (options) {
             text = options.isVerbose ? formatter.indent(result.description + ': failed', verboseIndent + 2) : 'F';
             formatter.print(formatter.colorize('red', text));
         }
-        if (options.isVerbose) {
+        if (options.isVerbose && result.status !== 'disabled') {
             formatter.printNewline();
         }
     };

--- a/tests/reporter.spec.js
+++ b/tests/reporter.spec.js
@@ -360,6 +360,36 @@ describe('The reporter', function () {
 
                 assert.strictEqual(printed, '\x1B[31m  a spec that fails: failed\x1B[0m\n');
             });
+
+            it('displays a non-disabled spec correctly', function () {
+                var printed = '';
+                var print = function (str) {
+                    printed += str;
+                };
+
+                var reporter = new Reporter({
+                    print: print,
+                    isVerbose: true
+                });
+
+                reporter.specDone({});
+                assert.strictEqual(printed, '\n');
+            });
+
+            it('displays a disabled spec correctly', function () {
+                var printed = '';
+                var print = function (str) {
+                    printed += str;
+                };
+
+                var reporter = new Reporter({
+                    print: print,
+                    isVerbose: true
+                });
+
+                reporter.specDone({ status: 'disabled' });
+                assert.strictEqual(printed, '');
+            });
         });
     });
 


### PR DESCRIPTION
When in verbose mode and use jasmine function `fit()` or `xit()` to disable a bunch of tests, the disabled tests used to print an empty line resulting in a lot of empty space generated in the terminal.

This commit fixes this issue.